### PR TITLE
Refactor duplicated code into new method getColumnNames

### DIFF
--- a/Overflowable.php
+++ b/Overflowable.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CraftLogan\LaravelOverflow;
+use Illuminate\Support\Facades\Schema;
+
+trait Overflowable{
+
+    public function allWithOverflow()
+    {
+        $properties[$this->overflow_column] = $this->overflow();
+        return array_merge($properties, $this->getColumns());
+    }
+
+    public function getColumns()
+    {
+        $columnNames = $this->getColumnNames();
+        $attributes = array_intersect_key($this->all(), $columnNames);
+        return $attributes;
+    }
+
+    public function overflow()
+    {
+        $columnNames = $this->getColumnNames();
+        $attributes = array_diff_key($this->all(), $columnNames);
+        $attributes = json_encode($attributes);
+        return $attributes;
+    }
+
+    public function getTableColumns()
+    {
+        return Schema::getColumnListing($this->table);
+    }
+
+    public function getColumnNames()
+    {
+        $columnNames = $this->getTableColumns();
+        $columnNames = array_fill_keys($columnNames, "");
+        return $columnNames;
+    }
+}


### PR DESCRIPTION
We can refactor creating a method getColumnNames instead of using the same code twice in Overflowable trait

```php
    public function getColumnNames()
    {
        $columnNames = $this->getTableColumns();
        $columnNames = array_fill_keys($columnNames, "");
        return $columnNames;
    }
```